### PR TITLE
reset worker num when less than inputfile number

### DIFF
--- a/src/main/java/net/qihoo/xlearning/AM/ApplicationMaster.java
+++ b/src/main/java/net/qihoo/xlearning/AM/ApplicationMaster.java
@@ -467,6 +467,7 @@ public class ApplicationMaster extends CompositeService {
           input2FileStatus.put(inputPathTuple[1], fileStatus);
           if (fileStatus.size() > 0) {
             if (fileStatus.size() < workerNum) {
+              workerNum = fileStatus.size();
               LOG.warn("File count in  " + inputPathRemote + "  " + fileStatus.size() +
                   " less than the worker count " + workerNum);
             }


### PR DESCRIPTION
When the number of worker specified less than the number inputfile normal input strategy ，we should reset it.