### PR TITLE
xlearning container allocate port from 20000 to 30000 by default

### DIFF
--- a/src/main/java/net/qihoo/xlearning/conf/XLearningConfiguration.java
+++ b/src/main/java/net/qihoo/xlearning/conf/XLearningConfiguration.java
@@ -267,6 +267,14 @@ public class XLearningConfiguration extends YarnConfiguration {
 
   public static final boolean DEFAULT_XLEARNING_CONTAINER_AUTO_CREATE_OUTPUT_DIR = true;
 
+  public static final String XLEARNING_RESERVE_PORT_BEGIN = "xlearning.reserve.port.begin";
+
+  public static final int DEFAULT_XLEARNING_RESERVE_PORT_BEGIN = 20000;
+
+  public static final String XLEARNING_RESERVE_PORT_END = "xlearning.reserve.port.end";
+
+  public static final int DEFAULT_XLEARNING_RESERVE_PORT_END = 30000;
+
   /**
    * Configuration used in Log Dir
    */


### PR DESCRIPTION
目前xlearning 随机保留端口，在线上环境中如果worker数目比较多，很容易出现xlearning暂时释放的随机端口被其他应用占用，导致app训练失败。linux下随机端口的范围是32768  --> 61000, 所以改成从20000到30000的范围分配端口
